### PR TITLE
fix(css): sort keys alphabetically

### DIFF
--- a/example/internal/components/codeblock.go
+++ b/example/internal/components/codeblock.go
@@ -22,7 +22,8 @@ func Codeblock(props CodeblockProps) *g.HTMLElement {
 		Props: g.CSSProps{
 			"background-color": theme.Base02 + " !important",
 			"height":           "100%",
-			"border":           "1px solid " + theme.Green,
+			"border":           "1px solid",
+			"border-color":     theme.Green,
 			"padding":          "0.5rem",
 			"font-family":      "monospace !important",
 		},

--- a/render.go
+++ b/render.go
@@ -2,6 +2,7 @@ package gorgeous
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/google/uuid"
@@ -200,8 +201,17 @@ func renderClassList(classList []string) string {
 func renderCSSProps(name string, class CSSProps) CSS {
 	style := CSS("")
 
-	for key, value := range class {
-		style += CSS(fmt.Sprintf("\t%s: %s;\n", key, value))
+	keys := make([]string, len(class))
+	for key := range class {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		if key == "" {
+			continue
+		}
+		style += CSS(fmt.Sprintf("\t%s: %s;\n", key, class[key]))
 	}
 
 	return CSS(fmt.Sprintf("%s {\n%s}\n", name, style))


### PR DESCRIPTION
This PR sorts CSS keys alphabetically to ensure maximum compatibility for partial components. Eg:

If a CSSClass has both the `border` and `border-color` props, ensure `border` is rendered first in the list to ensure the color is rendered, rather than defaulting to black.