### PR TITLE
Feat/references easier js referencing

### DIFF
--- a/example/internal/components/body.go
+++ b/example/internal/components/body.go
@@ -11,7 +11,7 @@ func Body() *g.HTMLElement {
 	theme := prv.ThemeProvider.GetTheme()
 	classes := GetClassPallette()
 
-	titleId := "title-element"
+	titleRef := g.CreateRef("title-element")
 
 	// This is a simple example of how to use the Blend function to create a new CSS class from two existing classes.
 	// The new class will have the properties of both classes, with the properties of the second class taking precedence.
@@ -25,7 +25,7 @@ func Body() *g.HTMLElement {
 		},
 		Children: g.CE{
 			g.Empty(), // This should not render anything in the final HTML
-			PageTitle(PageTitleProps{Id: titleId, Title: "✨ Gorgeous ✨"}),
+			titleRef.Get(PageTitle(PageTitleProps{Title: "✨ Gorgeous ✨"})),
 			g.Div(g.EB{Children: g.CE{
 				g.P(g.EB{
 					Children:  g.CE{g.Text("Gorgeous is a server-side rendering library for Go, inspired by React and Flutter.")},
@@ -36,7 +36,7 @@ func Body() *g.HTMLElement {
 					Style:    g.CSSProps{"color": theme.Base2},
 				}),
 			}}),
-			CodeComparison(titleId),
+			CodeComparison(titleRef),
 			g.P(g.EB{
 				Children: g.CE{
 					g.Text("It's still in early development, but you can check out the source code for this page on "),

--- a/example/internal/components/codecomparison.go
+++ b/example/internal/components/codecomparison.go
@@ -5,13 +5,10 @@ import (
 
 	g "github.com/zaptross/gorgeous"
 	p "github.com/zaptross/gorgeous/example/internal/provider"
-	s "github.com/zaptross/gorgeous/example/internal/services"
 )
 
-func CodeComparison(titleElementId string) *g.HTMLElement {
+func CodeComparison(titleRef *g.Reference) *g.HTMLElement {
 	theme := p.ThemeProvider.GetTheme()
-
-	es := s.GetElementService()
 
 	g.Class(&g.CSSClass{
 		Selector: ".code-comparison-hover",
@@ -57,12 +54,11 @@ func CodeComparison(titleElementId string) *g.HTMLElement {
 			}),
 		},
 		Style:  g.CSSProps{},
-		Script: g.JavaScript(g.JavaScript(getMouseEventScript(es, titleElementId))),
+		Script: g.JavaScript(g.JavaScript(getMouseEventScript(titleRef))),
 	})
 }
 
-func getMouseEventScript(es string, titleId string) string {
-	titleElement := fmt.Sprintf(`%s('%s')`, es, titleId)
+func getMouseEventScript(title *g.Reference) string {
 	return fmt.Sprintf(`
 		thisElement.addEventListener('mouseover', () => {
 			%s?.classList.add('code-comparison-hover');
@@ -70,5 +66,5 @@ func getMouseEventScript(es string, titleId string) string {
 		thisElement.addEventListener('mouseout', () => {
 			%s?.classList.remove('code-comparison-hover');
 		});
-	`, titleElement, titleElement)
+	`, title.Javascript(), title.Javascript())
 }

--- a/reference.go
+++ b/reference.go
@@ -1,0 +1,152 @@
+package gorgeous
+
+import (
+	_ "embed"
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+type Reference struct {
+	name    string
+	element *HTMLElement
+}
+
+const (
+	ReferenceCacheServiceName = "referenceCache"
+	ReferenceCacheService     = `
+const referenceCache = {};
+
+const observer = new MutationObserver(function (mutations) {
+  mutations.forEach(function (mutation) {
+    if (mutation.type === "childList" && mutation.removedNodes.length > 0) {
+      const referencedElements = Object.keys(referenceCache).map(
+        (el) => referenceCache[el].id
+      );
+      if (referencedElements.includes(mutation.removedNodes[0].id)) {
+        delete referenceCache[mutation.removedNodes[0].id];
+      }
+    }
+  });
+});
+
+// Get and cache a reference to the element with the given id
+// if it is not already cached, otherwise return the cached element.
+// Also setup an observer to remove the element from the cache if it is removed from the DOM.
+function referenceCacheGet(elementId) {
+  if (referenceCache[elementId] === undefined) {
+    referenceCache[elementId] = document.getElementById(elementId);
+    observer.observe(referenceCache[elementId].parentNode, {childList: true});
+  }
+  return referenceCache[elementId];
+}
+`
+)
+
+// CreateRef creates a reference to an element in the DOM.
+// This is useful for creating interactive components, such as modals, forms, and popovers.
+func CreateRef(name string) *Reference {
+	Service(ReferenceCacheServiceName, ReferenceCacheService)
+
+	return &Reference{
+		name: name,
+	}
+}
+
+// Get stores a reference to the element in the DOM, for later use, returning it
+// so that it can be used in the component.
+//
+// // Create a reference to a form field for use in a script.
+//
+//	func LoginForm() *g.HTMLElement {
+//		unRef := g.CreateRef("username")
+//		pwRef := g.CreateRef("password")
+//
+//		return g.Form(g.EB{
+//			Children: g.CE{
+//				unRef.Get(g.Input(g.EB{
+//					Props: g.Props{
+//						"type":        "email",
+//						"placeholder": "Username",
+//					},
+//				})),
+//				pwRef.Get(g.Input(g.EB{
+//					Props: g.Props{
+//						"type":        "password",
+//						"placeholder": "Password",
+//					},
+//				})),
+//			},
+//			Script: fmt.Sprintf(`
+//				const un = %s;
+//				const pw = %s;
+//
+//				fetch("/login", {
+//					method: "POST",
+//					body: JSON.stringify({
+//						username: un.value,
+//						password: pw.value,
+//					}),
+//				}).then(/* ... */)
+//			`, unRef.Element(), pwRef.Element()),
+//		})
+//	}
+func (r *Reference) Get(el *HTMLElement) *HTMLElement {
+	if el.Id == "" || el.EB.Id == "" {
+		el.Id = uuid.New().String()
+	}
+
+	r.element = el
+
+	return r.element
+}
+
+// Javascript returns a javascript expression that can be used to reference the element.
+// This is cached on the first lookup to avoid unnecessary DOM lookups.
+//
+// Note: this will return undefined if the element is not in the DOM.
+// It is recommended to use nullish chaining to avoid errors.
+//
+// eg:
+//
+//	const el = referenceCacheGet("myElementId")?.value;
+//	if (el === undefined) {
+//		// ...
+func (r *Reference) Javascript() JavaScript {
+	return JavaScript(fmt.Sprintf(`referenceCacheGet("%s")`, r.element.Id))
+}
+
+// Element returns the element that the reference points to.
+// This is useful for passing the element to a function in Go.
+//
+// Note: this will return nil if the element has not been set.
+// If you are using the ref within the same component, you should use the element directly,
+// or consider moving the ref to the higher level component.
+//
+// eg:
+//
+//			func MyHigherComponent() *g.HTMLElement {
+//					ref := g.CreateRef("myElement")
+//			   // ...
+//			   return g.Div(g.EB{
+//		       Children: g.CE{
+//	 	       MyComponent(ref)
+//					 },
+//			     Script: fmt.Sprintf(`
+//			       const el = %s;
+//			       // ...
+//			     `, ref.Element()),
+//		    }
+//			}
+//
+//			func MyComponent(ref *g.Reference) *g.HTMLElement {
+//			   // ...
+//			   return g.Div(g.EB{
+//			     Children: g.CE{
+//			       ref.Get(g.Input(g.EB{})),
+//			     }
+//			   })
+//			}
+func (r *Reference) Element() *HTMLElement {
+	return r.element
+}

--- a/reference_test.go
+++ b/reference_test.go
@@ -1,0 +1,51 @@
+package gorgeous
+
+import "testing"
+
+func TestCreateRef(t *testing.T) {
+	ref := CreateRef("test")
+
+	if ref.name != "test" {
+		t.Errorf("CreateRef(\"test\") did not set name to \"test\", got: \"%s\"", ref.name)
+	}
+}
+
+func TestReferenceGet(t *testing.T) {
+	ref := CreateRef("test")
+	el := Div(EB{})
+	ref.Get(el)
+
+	if ref.element.Id != el.Id {
+		t.Errorf("Get(el) did not set elementId to el.Id, got: \"%s\"", ref.element.Id)
+	}
+}
+
+func TestReferenceJavascript(t *testing.T) {
+	ref := CreateRef("test")
+	el := Div(EB{})
+	ref.Get(el)
+
+	if ref.Javascript().String() != "referenceCacheGet(\""+el.Id+"\")" {
+		t.Errorf("Element() did not return \"referenceCacheGet(\"+el.Id+\")\", got: \"%s\"", ref.Javascript())
+	}
+}
+
+func TestReferenceCacheServiceAdded(t *testing.T) {
+	ref := CreateRef("test")
+	el := Div(EB{})
+	ref.Get(el)
+
+	if services[ReferenceCacheServiceName] != ReferenceCacheService {
+		t.Errorf("ReferenceCacheService was not added to services map")
+	}
+}
+
+func TestReferenceElement(t *testing.T) {
+	ref := CreateRef("test")
+	el := Div(EB{})
+	ref.Get(el)
+
+	if ref.Element() != el {
+		t.Errorf("Element() did not return el, got: \"%v\"", ref.Element())
+	}
+}


### PR DESCRIPTION
This PR creates `Reference`s, which serve as a more easily manipulable method of referencing elements around the application, both in Go and Javascript.