### PR TITLE
Fix/handle eb onclick and props onclick

### DIFF
--- a/deferred_renderer.go
+++ b/deferred_renderer.go
@@ -51,7 +51,7 @@ func renderElementDeferredProps(element *HTMLElement, parentId string, innerText
 		`{
 		const ele = document.createElement("%s");
 		ele.id = "%s";
-		ele.onclick = "%s";
+		%s
 		ele.style = "%s";
 		%s
 		%s
@@ -63,7 +63,7 @@ func renderElementDeferredProps(element *HTMLElement, parentId string, innerText
 		`,
 		element.Tag,
 		element.EB.Id,
-		element.EB.OnClick,
+		renderDeferredOnClick(element.EB.OnClick, element.EB.Props),
 		renderDeferredStyles(element.EB.Style),
 		renderDeferredClassList(element.EB.ClassList),
 		renderElementDeferredTextProps(element.EB.Props),
@@ -116,8 +116,30 @@ func renderElementDeferredTextProps(props Props) JavaScript {
 	var script JavaScript
 
 	for _, key := range keys {
+		if key == "onclick" {
+			continue // onclick is handled separately
+		}
 		script += JavaScript(fmt.Sprintf(`ele.%s = "%s";\n`, key, props[key]))
 	}
 
 	return script
+}
+
+func renderDeferredOnClick(onClick JavaScript, props Props) string {
+	if onClick == "" && props != nil && props["onclick"] == "" {
+		return ""
+	}
+
+	onClickScript := ""
+	if props != nil && props["onclick"] != "" {
+		onClickScript = props["onclick"]
+	}
+	if onClickScript != "" && onClick != "" {
+		onClickScript += ";"
+	}
+	if onClick != "" {
+		onClickScript += string(onClick)
+	}
+
+	return fmt.Sprintf(`		ele.onclick = "%s";`, onClickScript)
 }

--- a/deferred_renderer_test.go
+++ b/deferred_renderer_test.go
@@ -49,7 +49,8 @@ func TestRenderElementDeferredTextPropsTableDriven(t *testing.T) {
 	}{
 		{Props{}, ""},
 		{Props{"id": "test"}, `ele.id = "test";\n`},
-		{Props{"id": "test", "onclick": "test"}, `ele.id = "test";\nele.onclick = "test";\n`},
+		// test that onclick is handled separately
+		{Props{"id": "test", "onclick": "test"}, `ele.id = "test";\n`},
 	}
 
 	for _, test := range tests {
@@ -57,6 +58,27 @@ func TestRenderElementDeferredTextPropsTableDriven(t *testing.T) {
 
 		if output.String() != test.expected {
 			t.Errorf("renderElementDeferredTextProps(%v) did not render \"%s\", got: \"%s\"", test.input, test.expected, output)
+		}
+	}
+}
+
+func TestRenderDeferredOnClickTableDriven(t *testing.T) {
+	tests := []struct {
+		OnClick      string
+		PropsOnClick string
+		expected     string
+	}{
+		{"", "", ""},
+		{"clip()", "", `		ele.onclick = "clip()";`},
+		{"", "clip()", `		ele.onclick = "clip()";`},
+		{"clip()", "clip()", `		ele.onclick = "clip();clip()";`},
+	}
+
+	for _, test := range tests {
+		output := renderDeferredOnClick(JavaScript(test.OnClick), Props{"onclick": test.PropsOnClick})
+
+		if output != test.expected {
+			t.Errorf("renderDeferredOnClick(%v) did not render \"%s\", got: \"%s\"", test.OnClick, test.expected, output)
 		}
 	}
 }

--- a/render.go
+++ b/render.go
@@ -141,6 +141,18 @@ func renderElementProps(element *HTMLElement) HTML {
 		text = element.Text
 	}
 
+	if element.OnClick != "" {
+		if element.EB.Props == nil {
+			element.EB.Props = Props{}
+		}
+
+		if element.EB.Props["onclick"] != "" {
+			element.EB.Props["onclick"] += ";" + string(element.OnClick)
+		} else {
+			element.EB.Props["onclick"] = string(element.OnClick)
+		}
+	}
+
 	return HTML(fmt.Sprintf(
 		`%s %s>%s`,
 		element.OpenTag,
@@ -269,6 +281,9 @@ func renderTextProps(props Props) string {
 	renderedProps := []string{}
 
 	for _, key := range keys {
+		if key == "" || props[key] == "" {
+			continue
+		}
 		renderedProps = append(renderedProps, fmt.Sprintf(`%s="%s"`, key, strings.ReplaceAll(props[key], `"`, `'`)))
 	}
 

--- a/render_test.go
+++ b/render_test.go
@@ -56,8 +56,11 @@ func TestRenderTextPropsTableDriven(t *testing.T) {
 		{Props{}, ""},
 		{Props{"test": "test"}, "test=\"test\""},
 		{Props{"test": "test", "test2": "test2"}, "test=\"test\" test2=\"test2\""},
-		// tests that the rendered props are sorted alphabetically
+		// test that the rendered props are sorted alphabetically
 		{Props{"zzz": "zzz", "aaa": "aaa"}, "aaa=\"aaa\" zzz=\"zzz\""},
+		// test that empty keys and values are ignored
+		{Props{"": "nope", "test": "test"}, "test=\"test\""},
+		{Props{"nope": "", "test": "test"}, "test=\"test\""},
 	}
 
 	for _, test := range tests {
@@ -150,6 +153,31 @@ func TestRemoveEmptyStringsTableDriven(t *testing.T) {
 			if str != test.expected[i] {
 				t.Errorf("removeEmptyStrings(%v) did not return %v, got: %v", test.input, test.expected, output)
 			}
+		}
+	}
+}
+
+func TestRenderOnClickTableDriven(t *testing.T) {
+	tests := []struct {
+		OnClick      string
+		PropsOnClick string
+		Expected     string
+	}{
+		{"", "", `<div id="a"></div>`},
+		{"clip()", "", `<div id="a" onclick="clip()"></div>`},
+		{"", "clip()", `<div id="a" onclick="clip()"></div>`},
+		{"clip()", "clip()", `<div id="a" onclick="clip();clip()"></div>`},
+	}
+
+	for _, test := range tests {
+		ele := Div(EB{
+			Id:      "a",
+			OnClick: JavaScript(test.OnClick),
+			Props:   Props{"onclick": test.PropsOnClick}})
+		output := RenderElement(ele, "")
+
+		if output.Document.String() != test.Expected {
+			t.Errorf("RenderElement(%v) did not render \"%s\", got: \"%s\"", ele, test.Expected, output.Document.String())
 		}
 	}
 }

--- a/types.go
+++ b/types.go
@@ -45,8 +45,15 @@ type CSSProps = map[string]string
 // It has been shortened to EB to reduce the amount of typing required to create
 type EB struct {
 	// html element attributes
-	Id        string
-	OnClick   string
+	Id string
+	// The attribute which specified the onclick event handler for the element.
+	// This is a string containing JavaScript code which is executed when the
+	// element is clicked.
+	//
+	// If both OnClick and Props["onclick"] are specified, then the two values
+	// will be concatenated with a semicolon. Props["onclick"] will be executed
+	// first.
+	OnClick   JavaScript
 	Style     CSSProps
 	ClassList []string
 


### PR DESCRIPTION
I noticed while working on another project that `EB.OnClick` was not being rendered, and upon investigation found that it was only considered for rendering during `renderElementDeferred()`.

When digging into the issue, I found that there could be cases where `onclick` is rendered twice if both are supplied, so I have put in the following fixes:
* `EB.OnClick` is now rendered for both static and deferred elements
* if both `EB.OnClick` and `Props["onclick"]` are present, they will both be rendered:
  * `Props["onclick"]` will be rendered first
  * `EB.OnClick` will be concatenated onto it, with a `;` between them